### PR TITLE
chore: update export-ignore patterns

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,17 +1,26 @@
-.env               export-ignore
-.env.*             export-ignore
-client_secret*     export-ignore
-*.pem              export-ignore
-*.key              export-ignore
-*.p12              export-ignore
-*.crt              export-ignore
-*.der              export-ignore
+.env export-ignore
+.env.* export-ignore
+client_secret* export-ignore
+*.pem export-ignore
+*.key export-ignore
+*.p12 export-ignore
+*.crt export-ignore
+*.der export-ignore
 
-node_modules/      export-ignore
-dist/              export-ignore
-coverage/          export-ignore
-data/              export-ignore
+*.log export-ignore
+bot-debug.log export-ignore
+todo-mcp-debug.log export-ignore
 
-.DS_Store          export-ignore
-Thumbs.db          export-ignore
-.gitattributes     export-ignore
+node_modules/ export-ignore
+dist/ export-ignore
+coverage/ export-ignore
+
+spec/ export-ignore
+scripts/dev/ export-ignore
+docs/internal/ export-ignore
+data/ export-ignore
+
+.DS_Store export-ignore
+Thumbs.db export-ignore
+.gitattributes export-ignore
+


### PR DESCRIPTION
## Summary
- expand `.gitattributes` export-ignore patterns for secrets, logs, builds, and internal dirs

## Testing
- `npm test` *(fails: ExternalServiceError: Cannot read properties of undefined (reading 'choices'))*
- `npm run lint` *(fails: ESLint couldn't find the config "@typescript-eslint/recommended")*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68956ad1190483338d4902d0fb905d1b