### PR TITLE
Add master key and optional OpenAI base URL to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,5 @@ DATA_PATH=./data
 
 # For command registration
 TEST_GUILD_ID=your_test_guild_id_here
+CONFIG_MASTER_KEY=__32byte_hex_or_base64_key__  # used to encrypt user secrets (AES-256-GCM)
+# (optional) OPENAI_BASE_URL=https://api.openai.com/v1


### PR DESCRIPTION
## Summary
- document CONFIG_MASTER_KEY for encrypting user secrets
- mention optional OPENAI_BASE_URL override

## Testing
- `npm test` *(fails: ExternalServiceError: OpenAI service error)*
- `npm run lint` *(fails: ESLint couldn't find the config "@typescript-eslint/recommended")*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68956ad6a7c8833382955984bc4f1e0f